### PR TITLE
Updated sqlx to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ cqrs-es = "0.4.11"
 
 async-trait = "0.1"
 futures = "0.3"
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.7", features = ["postgres", "json"] }
+sqlx = { version = "0.8", features = ["postgres", "json"] }
 tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
-uuid = { version = "1.7", features = ["v4"]}
+uuid = { version = "1.7", features = ["v4"] }
 
 [features]
 default = ["runtime-tokio-rustls"]


### PR DESCRIPTION
With sqlx 0.8 the sqlite3 bindings have changed so projects using postgres-es get a compile error if they want to update their sqlx version.
Error looks like this:
```
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `sqlx-sqlite v0.7.0`
    ... which satisfies dependency `sqlx-sqlite = "=0.7.0"` of package `sqlx v0.7.0`
    ... which satisfies dependency `sqlx = "^0.7"` of package `postgres-es v0.4.11`
    ... which satisfies dependency `postgres-es = "^0.4.11"` of package ...
```
I did not have sqlite in my project anywhere. Depending on the updated version resolves the issue.